### PR TITLE
Added automatic generation of splash images

### DIFF
--- a/README.org
+++ b/README.org
@@ -6,6 +6,7 @@
   - [[#description][Description]]
   - [[#variations][Variations]]
   - [[#make-your-own][Make your own]]
+  - [[#automatically-generate-in-emacs][Automatically generate in Emacs]]
 - [[#gnu-emacs][GNU Emacs]]
   - [[#description-1][Description]]
   - [[#variations-1][Variations]]
@@ -134,6 +135,116 @@ Save the script =recolor.sh= and the file =template.svg= together into one direc
 The script will ask you for several colors to give as an input. Input the colors as hexadecimal color code without a preceding:  =434c5e=. It will then spit out a file with the given colors into the directory it is run in.
 
 Make sure to make a pull request to this repo if you created some awesome images for a colorscheme that isn't added yet.  =;-)=
+
+** Automatically generate in Emacs
+Emacs can automatically generate generate the Doom Emacs logo for you. When ever you swich the color scheme, a new set of images is created and used.
+To do this, put the file ~doom-emacs-splash-template.svg~ (in the folder ~svg~ on this GitHub) into a subfolder ~splash~ in your Doom config directory (so usually ~~/.doom.d/splash/~).
+The elisp code below is shamelessly stolen from [[https://github.com/tecosaur/emacs-config][Tecosaur]] and slightly modified.
+#+begin_src elisp
+(defvar fancy-splash-image-template
+  (expand-file-name "splash/doom-emacs-splash-template.svg" doom-private-dir)
+  "Default template svg used for the splash image, with substitutions from ")
+
+(defvar fancy-splash-sizes
+  `((:height 500 :min-height 50 :padding (0 . 2))
+    (:height 450 :min-height 42 :padding (2 . 4))
+    (:height 400 :min-height 35 :padding (3 . 3))
+    (:height 350 :min-height 28 :padding (3 . 3))
+    (:height 200 :min-height 20 :padding (2 . 2))
+    (:height 150  :min-height 15 :padding (2 . 1))
+    (:height 100  :min-height 13 :padding (2 . 1))
+    (:height 75  :min-height 12 :padding (2 . 1))
+    (:height 50  :min-height 10 :padding (1 . 0))
+    (:height 1   :min-height 0  :padding (0 . 0)))
+  "list of plists with the following properties
+  :height the height of the image
+  :min-height minimum `frame-height' for image
+  :padding `+doom-dashboard-banner-padding' (top . bottom) to apply
+  :template non-default template file
+  :file file to use instead of template")
+
+(defvar fancy-splash-template-colours
+  '(("$color1" . functions) ("$color2" . keywords) ("$color3" .  highlight) ("$color4" . bg) ("$color5" . bg) ("$color6" . base0))
+  ;; 1: Text up, 2: Text low, 3: upper outlines, 4: shadow, 5: background, 6: gradient to middle
+  "list of colour-replacement alists of the form (\"$placeholder\" . 'theme-colour) which applied the template")
+
+(unless (file-exists-p (expand-file-name "theme-splashes" doom-cache-dir))
+  (make-directory (expand-file-name "theme-splashes" doom-cache-dir) t))
+
+(defun fancy-splash-filename (theme-name height)
+  (expand-file-name (concat (file-name-as-directory "theme-splashes")
+                            theme-name
+                            "-" (number-to-string height) ".svg")
+                    doom-cache-dir))
+
+(defun fancy-splash-clear-cache ()
+  "Delete all cached fancy splash images"
+  (interactive)
+  (delete-directory (expand-file-name "theme-splashes" doom-cache-dir) t)
+  (message "Cache cleared!"))
+
+(defun fancy-splash-generate-image (template height)
+  "Read TEMPLATE and create an image if HEIGHT with colour substitutions as
+   described by `fancy-splash-template-colours' for the current theme"
+  (with-temp-buffer
+    (insert-file-contents template)
+    (re-search-forward "$height" nil t)
+    (replace-match (number-to-string height) nil nil)
+    (replace-match (number-to-string height) nil nil)
+    (dolist (substitution fancy-splash-template-colours)
+      (goto-char (point-min))
+      (while (re-search-forward (car substitution) nil t)
+        (replace-match (doom-color (cdr substitution)) nil nil)))
+    (write-region nil nil
+                  (fancy-splash-filename (symbol-name doom-theme) height) nil nil)))
+
+(defun fancy-splash-generate-images ()
+  "Perform `fancy-splash-generate-image' in bulk"
+  (dolist (size fancy-splash-sizes)
+    (unless (plist-get size :file)
+      (fancy-splash-generate-image (or (plist-get size :template)
+                                       fancy-splash-image-template)
+                                   (plist-get size :height)))))
+
+(defun ensure-theme-splash-images-exist (&optional height)
+  (unless (file-exists-p (fancy-splash-filename
+                          (symbol-name doom-theme)
+                          (or height
+                              (plist-get (car fancy-splash-sizes) :height))))
+    (fancy-splash-generate-images)))
+
+(defun get-appropriate-splash ()
+  (let ((height (frame-height)))
+    (cl-some (lambda (size) (when (>= height (plist-get size :min-height)) size))
+             fancy-splash-sizes)))
+
+(setq fancy-splash-last-size nil)
+(setq fancy-splash-last-theme nil)
+(defun set-appropriate-splash (&rest _)
+  (let ((appropriate-image (get-appropriate-splash)))
+    (unless (and (equal appropriate-image fancy-splash-last-size)
+                 (equal doom-theme fancy-splash-last-theme)))
+    (unless (plist-get appropriate-image :file)
+      (ensure-theme-splash-images-exist (plist-get appropriate-image :height)))
+    (setq fancy-splash-image
+          (or (plist-get appropriate-image :file)
+              (fancy-splash-filename (symbol-name doom-theme) (plist-get appropriate-image :height))))
+    (setq +doom-dashboard-banner-padding (plist-get appropriate-image :padding))
+    (setq fancy-splash-last-size appropriate-image)
+    (setq fancy-splash-last-theme doom-theme)
+    (+doom-dashboard-reload)))
+
+(add-hook 'window-size-change-functions #'set-appropriate-splash)
+(add-hook 'doom-load-theme-hook #'set-appropriate-splash)
+
+#+end_src
+
+Look in your theme what the different colors are called. If you want to use a different color, but still want to keep the automatic generation, you can change the line
+#+begin_src elisp
+  '(("$color1" . functions) ("$color2" . keywords) ("$color3" .  highlight) ("$color4" . bg) ("$color5" . bg) ("$color6" . base0))
+#+end_src
+
+This snippet above automatically generates a set of images and puts them into your Emacs' temp folder. So it does not always generate new images every time you start up Emacs. If you changed some of the colors and want to generate new images, use ~M-x fancy-splash-clear-cache~.
 
 * GNU Emacs
 

--- a/svg/doom-emacs-splash-template.svg
+++ b/svg/doom-emacs-splash-template.svg
@@ -1,0 +1,339 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+
+<svg
+   sodipodi:docname="doomEmacs.svg"
+   inkscape:version="1.1.2 (0a00cf5339, 2022-02-04, custom)"
+   id="svg5"
+   version="1.1"
+   viewBox="0 0 142.78185 142.78186"
+   height="$height"
+   width="$height"
+   inkscape:export-filename="/home/halcyon/Pictures/graphics/png/doom/doom1024.png"
+   inkscape:export-xdpi="192"
+   inkscape:export-ydpi="192"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <title
+     id="title859">Doom Logo</title>
+  <sodipodi:namedview
+     id="namedview7"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageshadow="2"
+     inkscape:pageopacity="0"
+     inkscape:pagecheckerboard="false"
+     inkscape:document-units="px"
+     showgrid="false"
+     units="px"
+     showborder="true"
+     inkscape:snap-bbox="true"
+     inkscape:bbox-paths="true"
+     inkscape:bbox-nodes="true"
+     inkscape:object-paths="true"
+     inkscape:zoom="0.35355339"
+     inkscape:cx="841.45707"
+     inkscape:cy="319.61226"
+     inkscape:window-width="1356"
+     inkscape:window-height="740"
+     inkscape:window-x="5"
+     inkscape:window-y="23"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="layer1"
+     inkscape:snap-global="true"
+     inkscape:snap-midpoints="true" />
+  <defs
+     id="defs2">
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient205766">
+      <stop
+         style="stop-color:$color1;stop-opacity:1"
+         offset="0"
+         id="stop205762" />
+      <stop
+         style="stop-color:$color2;stop-opacity:1"
+         offset="1"
+         id="stop205764" />
+    </linearGradient>
+    <filter
+       inkscape:collect="always"
+       style="color-interpolation-filters:sRGB"
+       id="filter226062-6"
+       x="-0.3"
+       y="-0.3"
+       width="1.6"
+       height="1.6">
+      <feGaussianBlur
+         inkscape:collect="always"
+         stdDeviation="6.0859423"
+         id="feGaussianBlur226064-2" />
+    </filter>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient205766"
+       id="linearGradient1467"
+       gradientUnits="userSpaceOnUse"
+       x1="156.67468"
+       y1="94.809441"
+       x2="156.67468"
+       y2="128.78041" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient205766"
+       id="linearGradient1469"
+       gradientUnits="userSpaceOnUse"
+       x1="156.67468"
+       y1="94.809441"
+       x2="156.67468"
+       y2="128.78041" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient205766"
+       id="linearGradient1471"
+       gradientUnits="userSpaceOnUse"
+       x1="156.67468"
+       y1="94.809441"
+       x2="156.67468"
+       y2="128.78041" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient205766"
+       id="linearGradient1473"
+       gradientUnits="userSpaceOnUse"
+       x1="156.67468"
+       y1="94.809441"
+       x2="156.67468"
+       y2="128.78041" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient205766"
+       id="linearGradient1475"
+       gradientUnits="userSpaceOnUse"
+       x1="156.67468"
+       y1="94.809441"
+       x2="156.67468"
+       y2="128.78041" />
+    <filter
+       inkscape:collect="always"
+       style="color-interpolation-filters:sRGB"
+       id="filter1319"
+       x="-0.026999999"
+       y="-0.026999999"
+       width="1.054"
+       height="1.054">
+      <feGaussianBlur
+         inkscape:collect="always"
+         stdDeviation="1.5239997"
+         id="feGaussianBlur1321" />
+    </filter>
+  </defs>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     transform="translate(-433.5369,77.773083)">
+    <g
+       id="g1358">
+      <circle
+         style="fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.767386;filter:url(#filter1319)"
+         id="circle867"
+         cx="504.92783"
+         cy="-6.3821611"
+         r="67.733322" />
+      <g
+         id="g18922">
+        <g
+           id="g18543"
+           transform="matrix(2.2243578,0,0,2.2243578,-535.28249,90.743868)">
+          <circle
+             style="fill:$color5;fill-opacity:1;stroke:none;stroke-width:0.344992"
+             id="path224903-1"
+             cx="467.64523"
+             cy="-43.664749"
+             r="30.450733" />
+          <circle
+             style="mix-blend-mode:normal;fill:$color6;fill-opacity:1;stroke:none;stroke-width:0.275803;filter:url(#filter226062-6)"
+             id="circle226042"
+             cx="238.59868"
+             cy="112.83595"
+             r="24.343769"
+             transform="matrix(0.7817897,0,0,0.7817897,281.11125,-131.87873)" />
+        </g>
+        <g
+           id="g18437"
+           transform="matrix(2.077781,0,0,2.0777904,-186.66152,33.125795)">
+          <g
+             id="g18389">
+            <g
+               id="g203670"
+               style="font-size:4.27239px;line-height:1.25;font-family:AmazDooMLeft;-inkscape-font-specification:AmazDooMLeft;fill:$color2;stroke-width:0.106809"
+               transform="matrix(3.0430214,0,0,3.0430214,69.89449,-214.06558)">
+              <path
+                 d="m 83.219017,68.332979 v 0.39306 l 0.28625,0.243526 V 68.49533 h 0.521231 v 0.534049 l -0.704944,0.516959 -0.593862,-0.474236 v -1.982388 l 0.183712,-0.205075 h 0.922837 l 0.192257,0.192257 v 0.598135 h -0.521231 v -0.281978 h -0.28625 v 0.418694 h 0.277705 v 0.521232 z"
+                 id="path203660"
+                 style="fill:$color2" />
+              <path
+                 d="m 85.368032,66.884639 h 0.521232 v 2.14474 l -0.521232,0.380242 v -1.226176 l -0.341791,0.858751 -0.384515,-0.850206 v 1.217631 l -0.521232,-0.380242 v -2.14474 h 0.521232 l 0.341791,0.777575 z"
+                 id="path203662"
+                 style="fill:$color2" />
+              <path
+                 d="m 86.799279,68.123632 v -0.730579 h -0.28625 v 0.730579 z m -0.28625,0.508414 v 0.833116 l -0.491325,-0.39306 v -1.982388 l 0.183713,-0.205075 h 0.922836 l 0.192258,0.192257 v 1.995206 l -0.521232,0.39306 v -0.833116 z"
+                 id="path203664"
+                 style="fill:$color2" />
+              <path
+                 d="m 88.187809,67.675031 v -0.281978 h -0.28625 v 1.576512 l 0.28625,-0.239254 V 68.49533 h 0.521232 v 0.534049 l -0.704945,0.516959 -0.593862,-0.474236 v -1.982388 l 0.183713,-0.205075 h 0.922836 l 0.192258,0.192257 v 0.598135 z"
+                 style="font-family:AmazDooMRight;-inkscape-font-specification:AmazDooMRight;fill:$color2"
+                 id="path203666" />
+              <path
+                 d="m 88.798764,69.072102 v -0.435783 h 0.491325 v 0.324701 l 0.28625,-0.234981 V 68.456878 L 88.798764,68.01255 v -0.957016 l 0.132444,-0.170895 h 1.004012 l 0.162351,0.200802 v 0.435784 h -0.521232 v -0.153806 h -0.28625 v 0.414422 l 0.807482,0.427239 v 0.863022 l -0.700672,0.474236 z"
+                 style="font-family:AmazDooMRight;-inkscape-font-specification:AmazDooMRight;fill:$color2"
+                 id="path203668" />
+            </g>
+            <g
+               id="g225672"
+               transform="translate(175.81078,-131.46202)">
+              <path
+                 id="path220643"
+                 style="font-size:4.27239px;line-height:1.25;font-family:AmazDooMLeft;-inkscape-font-specification:AmazDooMLeft;fill:$color4;fill-opacity:1;stroke-width:1.22843"
+                 d="m 559.39648,349.91992 v 4 h 3.29297 v 3.24219 h 5.99414 v -4 h -5.99414 v -3.24219 z m 0,10.81055 v 4 h 3.19532 v -4 z m 9.28711,8.00976 -8.10742,5.94532 -6.83008,-5.45508 v 4 l 6.83008,5.45508 8.10742,-5.94532 z"
+                 transform="matrix(0.26458333,0,0,0.26458333,-0.68624115,29.891956)" />
+              <path
+                 id="path220645"
+                 style="font-size:4.27239px;line-height:1.25;font-family:AmazDooMLeft;-inkscape-font-specification:AmazDooMLeft;fill:$color4;fill-opacity:1;stroke-width:1.22843"
+                 d="m 584.11328,359.00977 -3.93164,9.87695 -4.42187,-9.77734 v 4 l 4.42187,9.77734 3.93164,-9.87695 z m -14.34766,9.73046 v 4 l 5.99415,4.37305 v -4 z m 20.3418,0 -5.99414,4.37305 v 4 l 5.99414,-4.37305 z"
+                 transform="matrix(0.26458333,0,0,0.26458333,-0.68624115,29.891956)" />
+              <path
+                 id="path220647"
+                 style="font-size:4.27239px;line-height:1.25;font-family:AmazDooMLeft;-inkscape-font-specification:AmazDooMLeft;fill:$color4;fill-opacity:1;stroke-width:1.22843"
+                 d="m 597.2832,349.91992 v 4 h 3.29102 v -4 z m 0,14.25 v 4 h 3.29102 v -4 z m -5.65234,5.06055 v 4 l 5.65234,4.52148 v -4 z m 14.9375,0 -5.99414,4.52148 v 4 l 5.99414,-4.52148 z"
+                 transform="matrix(0.26458333,0,0,0.26458333,-0.68624115,29.891956)" />
+              <path
+                 id="path220649"
+                 style="font-size:4.27239px;line-height:1.25;font-family:AmazDooMRight;-inkscape-font-specification:AmazDooMRight;fill:$color4;fill-opacity:1;stroke-width:1.22843"
+                 d="m 613.25195,349.91992 v 4 h 3.29297 v 3.24219 h 5.99414 v -4 h -5.99414 v -3.24219 z m 9.28711,18.82031 -8.10742,5.94532 -6.83008,-5.45508 v 4 l 6.83008,5.45508 8.10742,-5.94532 z"
+                 transform="matrix(0.26458333,0,0,0.26458333,-0.68624115,29.891956)" />
+              <path
+                 id="path220651"
+                 style="font-size:4.27239px;line-height:1.25;font-family:AmazDooMRight;-inkscape-font-specification:AmazDooMRight;fill:$color4;fill-opacity:1;stroke-width:1.22843"
+                 d="m 629.22266,349.625 v 4 h 3.29101 v 1.76953 h 5.9961 v -4 h -5.9961 V 349.625 Z m -5.65235,7.41992 v 4 l 5.55469,3.17383 h 0.0977 v 0.0547 l 2.64257,1.50976 0.64844,-0.5332 v -3.0957 z m 0,12.18555 v 4 l 6.88086,5.45508 8.0586,-5.45508 v -4 l -8.0586,5.45508 z"
+                 transform="matrix(0.26458333,0,0,0.26458333,-0.68624115,29.891956)" />
+            </g>
+          </g>
+          <g
+             id="g18406">
+            <g
+               id="g205760"
+               style="fill:url(#linearGradient1475);fill-opacity:1"
+               transform="translate(175.81078,-131.46202)">
+              <path
+                 d="m 142.62142,94.809393 2.18995,1.320416 v 15.844971 l -9.82259,7.85807 0.25766,-0.6119 V 95.614525 l -0.64411,-0.805132 z M 138.789,98.60961 v 12.39901 l 2.15775,-1.64247 V 98.60961 Z"
+                 id="path203652"
+                 style="font-size:10.5833px;line-height:1.25;font-family:AmazDooMLeft;-inkscape-font-specification:AmazDooMLeft;fill:url(#linearGradient1467);fill-opacity:1;stroke-width:0.805132" />
+              <path
+                 d="m 154.18894,94.809393 1.44924,1.449236 v 14.717781 l -5.31386,3.89683 -4.47652,-3.57477 V 96.355245 l 1.38482,-1.545852 z m -4.63755,3.832421 v 10.048026 l 2.15775,1.8357 V 98.641814 Z"
+                 id="path203654"
+                 style="font-size:10.5833px;line-height:1.25;font-family:AmazDooMLeft;-inkscape-font-specification:AmazDooMLeft;fill:url(#linearGradient1469);fill-opacity:1;stroke-width:0.805132" />
+              <path
+                 d="m 170.74845,106.24225 2.41539,8.59879 2.35098,-6.40884 v 8.56659 l -0.51528,0.74072 2.18995,1.64247 2.09334,1.54584 -0.41867,-1.93231 V 95.743345 l 0.6119,-0.933952 h -4.25109 l -1.99672,5.088425 -1.8679,-5.088425 h -4.12227 l 0.25766,0.772925 v 16.167022 l -0.22543,0.19323 3.47816,2.60862 z"
+                 id="path203656"
+                 style="font-size:10.5833px;line-height:1.25;font-family:AmazDooMLeft;-inkscape-font-specification:AmazDooMLeft;fill:url(#linearGradient1471);fill-opacity:1;stroke-width:0.805132" />
+              <path
+                 d="m 158.124,94.809393 -1.44923,1.449236 v 14.717781 l 5.31386,3.89683 4.47652,-3.57477 V 96.355245 l -1.38483,-1.545852 z m 4.63755,3.832421 v 10.048026 l -2.15775,1.8357 V 98.641814 Z"
+                 id="path203658"
+                 style="font-size:10.5833px;line-height:1.25;font-family:AmazDooMLeft;-inkscape-font-specification:AmazDooMLeft;fill:url(#linearGradient1473);fill-opacity:1;stroke-width:0.805132" />
+            </g>
+            <g
+               id="g225678"
+               transform="translate(175.81078,-131.46202)">
+              <path
+                 id="path203690"
+                 style="font-size:10.5833px;line-height:1.25;font-family:AmazDooMLeft;-inkscape-font-specification:AmazDooMLeft;fill:$color4;stroke-width:0.805132"
+                 d="m 149.55158,98.641767 v 3.175003 h 2.15749 v -3.175003 z m 6.08645,12.334653 -5.31389,3.89692 -4.47621,-3.57498 v 3.175 l 4.47621,3.57498 5.31389,-3.89692 z" />
+              <path
+                 id="path203692"
+                 style="font-size:10.5833px;line-height:1.25;font-family:AmazDooMLeft;-inkscape-font-specification:AmazDooMLeft;fill:$color4;stroke-width:0.805132"
+                 d="m 160.60362,98.641767 v 3.175003 h 2.158 v -3.175003 z m -3.92896,12.334653 v 3.175 l 5.31388,3.89692 4.47673,-3.57498 v -3.175 l -4.47673,3.57498 z" />
+              <path
+                 id="path203694"
+                 style="fill:$color4;fill-opacity:1;stroke:none;stroke-width:0.264583px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+                 d="m 134.6021,94.809443 v 3.175 l 0.64441,0.805118 v -0.805118 -2.369882 z m 4.18683,3.800284 v 3.175003 h 2.158 v -3.175003 z m 6.02237,13.365083 -9.56479,7.65173 -0.25787,0.20619 v 3.175 l 9.82266,-7.85792 z" />
+              <path
+                 id="path203698"
+                 style="fill:$color4;stroke:none;stroke-width:0.264583px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+                 d="m 167.23784,94.809443 v 3.175 l 0.25786,0.77308 v -0.77308 -2.401921 z m 12.23801,0 -0.61185,0.933793 v 2.241207 0.933793 l 0.61185,-0.933793 z m -8.72763,11.432897 v 3.175 l 2.41587,8.59845 2.35076,-6.4084 v -3.175 l -2.35076,6.40839 z m -3.47783,5.70043 v 3.175 l 3.47783,2.60863 v -3.175 l -3.25252,-2.43965 z m 7.72925,5.79655 v 3.175 l 2.19004,1.64279 2.0929,1.54565 v -3.17501 l -0.41858,-0.30902 -1.67432,-1.23662 -1.67483,-1.25625 z" />
+            </g>
+            <g
+               id="g18183"
+               style="opacity:0.3">
+              <path
+                 id="path2054"
+                 style="font-size:10.5833px;line-height:1.25;font-family:AmazDooMLeft;-inkscape-font-specification:AmazDooMLeft;fill:$color3;stroke-width:0.805132"
+                 d="m 310.41329,-36.652627 0.64389,0.805119 v 0.253214 h 7.90391 l 1.66088,1.00149 v -0.738973 l -2.19004,-1.32085 z m 0.64389,1.201994 v 23.209953 l -0.25786,0.611849 0.78703,-0.62942 v -22.530924 z"
+                 sodipodi:nodetypes="cccccccccccccc" />
+              <path
+                 id="path2056"
+                 style="font-size:10.5833px;line-height:1.25;font-family:AmazDooMLeft;-inkscape-font-specification:AmazDooMLeft;fill:$color3;stroke-width:0.805132"
+                 d="m 323.04353,-36.652627 -1.38493,1.546158 v 14.943275 l 0.52917,0.422712 v -14.307653 l 1.38493,-1.546159 h 6.95616 l 0.91984,0.920358 v -0.529166 l -1.44901,-1.449525 z"
+                 sodipodi:nodetypes="ccccccccccc" />
+              <path
+                 id="path2060"
+                 style="font-size:10.5833px;line-height:1.25;font-family:AmazDooMLeft;-inkscape-font-specification:AmazDooMLeft;fill:$color3;stroke-width:0.805132"
+                 d="m 333.93486,-36.652627 -1.44953,1.449525 v 14.717963 l 0.52917,0.388091 v -14.047721 l 1.44952,-1.449525 h 6.95617 l 0.85576,0.955498 v -0.467673 l -1.38493,-1.546158 z"
+                 sodipodi:nodetypes="ccccccccccc" />
+              <path
+                 id="path4513"
+                 style="fill:$color3;fill-opacity:1;stroke:none;stroke-width:0.264583px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+                 d="m 349.11171,-31.749567 -0.0727,0.1856 0.45189,1.25479 0.0771,-0.19654 z m -6.06268,-4.90306 0.25735,0.77308 v 16.16697 l -0.22531,0.19327 0.75448,0.56586 v -15.86777 l -0.25735,-0.77308 h 3.98167 l -0.38861,-1.05833 z m 7.98659,0 -1.92391,4.90306 0.45631,1.24385 1.99677,-5.08858 h 3.10989 v -0.12402 l 0.61237,-0.93431 z" />
+            </g>
+          </g>
+        </g>
+      </g>
+    </g>
+  </g>
+  <metadata
+     id="metadata848">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <cc:license
+           rdf:resource="http://creativecommons.org/licenses/by-sa/4.0/" />
+        <dc:title>Doom Logo</dc:title>
+        <dc:date>07.05.22</dc:date>
+        <dc:rights>
+          <cc:Agent>
+            <dc:title>Creative Commons Attribution 4.0 International License</dc:title>
+          </cc:Agent>
+        </dc:rights>
+        <dc:source>https://github.com/tachanka61/graphics</dc:source>
+        <dc:description>Doom logo using nord colorscheme and AmazDoom font</dc:description>
+        <dc:creator>
+          <cc:Agent>
+            <dc:title>Tachanka</dc:title>
+          </cc:Agent>
+        </dc:creator>
+      </cc:Work>
+      <cc:License
+         rdf:about="http://creativecommons.org/licenses/by-sa/4.0/">
+        <cc:permits
+           rdf:resource="http://creativecommons.org/ns#Reproduction" />
+        <cc:permits
+           rdf:resource="http://creativecommons.org/ns#Distribution" />
+        <cc:requires
+           rdf:resource="http://creativecommons.org/ns#Notice" />
+        <cc:requires
+           rdf:resource="http://creativecommons.org/ns#Attribution" />
+        <cc:permits
+           rdf:resource="http://creativecommons.org/ns#DerivativeWorks" />
+        <cc:requires
+           rdf:resource="http://creativecommons.org/ns#ShareAlike" />
+      </cc:License>
+    </rdf:RDF>
+  </metadata>
+</svg>


### PR DESCRIPTION
I saw that Tecosaur made a great piece of elisp, that automatically generates the splash image against your theme colors. So I made this for the Doom logos here.  (https://github.com/tecosaur/emacs-config)

