### PR TITLE
Fix suggested auto-generation script

### DIFF
--- a/README.org
+++ b/README.org
@@ -189,6 +189,7 @@ The elisp code below is shamelessly stolen from [[https://github.com/tecosaur/em
     (insert-file-contents template)
     (re-search-forward "$height" nil t)
     (replace-match (number-to-string height) nil nil)
+    (re-search-forward "$height" nil t)
     (replace-match (number-to-string height) nil nil)
     (dolist (substitution fancy-splash-template-colours)
       (goto-char (point-min))


### PR DESCRIPTION
Without this change, only the svg height attribute is substituted. We need to search forward again to substitute the width.

Result after this change looks gorgeous:

![image](https://github.com/Schievel1/doom-emacs-splash/assets/7091399/cfc5ee1f-2f35-4dfb-82c0-b726d29a7cf0)
